### PR TITLE
Pref setting to hide 'Find albums...' items from Extra menu

### DIFF
--- a/HTML/EN/plugins/MusicArtistInfo/settings.html
+++ b/HTML/EN/plugins/MusicArtistInfo/settings.html
@@ -62,6 +62,11 @@
 			<input type="checkbox" [% IF prefs.pref_fallBackToEnglish %]checked [% END %] class="stdedit" name="pref_fallBackToEnglish" id="pref_fallBackToEnglish" value="1" />
 			<label for="pref_fallBackToEnglish" class="stdlabel">[% "PLUGIN_MUSICARTISTINFO_ENGLISH_CONTENT_FALLBACK" | string %]</label>
 		[% END %]
+
+		[% WRAPPER settingGroup title="PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS" desc="PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS_DESC" %]
+			<input type="checkbox" [% IF prefs.pref_hidextramenusitems %]checked [% END %] class="stdedit" name="pref_hidextramenusitems" id="pref_hidextramenusitems" value="1" />
+		[% END %]
+
 	[% END %]
 
 	[% IF noImageProxy; WRAPPER setting title="" desc="" %]

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -27,13 +27,13 @@ my $log = Slim::Utils::Log->addLogCategory( {
 	description  => 'PLUGIN_MUSICARTISTINFO',
 	logGroups    => 'SCANNER',
 } );
+my $prefs = preferences('plugin.musicartistinfo');
 
 sub initPlugin {
 	my $class = shift;
 
 	$VERSION = $class->_pluginDataFor('version');
 
-	my $prefs = preferences('plugin.musicartistinfo');
 	$prefs->init({
 		browseArtistPictures => 1,
 		runImporter => 1,
@@ -96,41 +96,43 @@ sub playerMenu {}
 sub webPages {
 	my $class = shift;
 
-	my $url = 'plugins/' . PLUGIN_TAG . '/missingartwork.html';
+	unless ($prefs->get('hidextramenusitems')) {
+		my $url = 'plugins/' . PLUGIN_TAG . '/missingartwork.html';
 
-	Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => $url } );
-	Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => "html/images/cover.png" });
+		Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => $url } );
+		Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => "html/images/cover.png" });
 
-	Slim::Web::Pages->addPageFunction( $url, sub {
-		my $client = $_[0];
+		Slim::Web::Pages->addPageFunction( $url, sub {
+			my $client = $_[0];
 
-		Slim::Web::XMLBrowser->handleWebIndex( {
-			client => $client,
-			path   => 'missingartwork.html',
-			feed   => \&getMissingArtworkAlbums,
-			type   => 'link',
-			title  => cstring($client, 'PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK'),
-			args   => \@_
+			Slim::Web::XMLBrowser->handleWebIndex( {
+				client => $client,
+				path   => 'missingartwork.html',
+				feed   => \&getMissingArtworkAlbums,
+				type   => 'link',
+				title  => cstring($client, 'PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK'),
+				args   => \@_
+			} );
 		} );
-	} );
 
-	$url = 'plugins/' . PLUGIN_TAG . '/smallartwork.html';
+		$url = 'plugins/' . PLUGIN_TAG . '/smallartwork.html';
 
-	Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => $url } );
-	Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => "html/images/cover.png" });
+		Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => $url } );
+		Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => "html/images/cover.png" });
 
-	Slim::Web::Pages->addPageFunction( $url, sub {
-		my $client = $_[0];
+		Slim::Web::Pages->addPageFunction( $url, sub {
+			my $client = $_[0];
 
-		Slim::Web::XMLBrowser->handleWebIndex( {
-			client => $client,
-			feed   => \&getSmallArtworkAlbums,
-			path   => 'smallartwork.html',
-			type   => 'link',
-			title  => cstring($client, 'PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK'),
-			args   => \@_
+			Slim::Web::XMLBrowser->handleWebIndex( {
+				client => $client,
+				feed   => \&getSmallArtworkAlbums,
+				path   => 'smallartwork.html',
+				type   => 'link',
+				title  => cstring($client, 'PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK'),
+				args   => \@_
+			} );
 		} );
-	} );
+	}
 }
 
 sub getMissingArtworkAlbums {

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -42,6 +42,7 @@ sub initPlugin {
 		lookupAlbumArtistPicturesOnly => 1,
 		fallBackToEnglish => 1,
 	});
+	$prefs->setChange(\&webPages, 'hidextramenusitems');
 
 	Plugins::MusicArtistInfo::AlbumInfo->init($class);
 	Plugins::MusicArtistInfo::ArtistInfo->init($class);
@@ -96,9 +97,8 @@ sub playerMenu {}
 sub webPages {
 	my $class = shift;
 
-	unless ($prefs->get('hidextramenusitems')) {
-		my $url = 'plugins/' . PLUGIN_TAG . '/missingartwork.html';
-
+	my $url = 'plugins/' . PLUGIN_TAG . '/missingartwork.html';
+	if (!$prefs->get('hidextramenusitems')) {
 		Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => $url } );
 		Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK => "html/images/cover.png" });
 
@@ -114,9 +114,13 @@ sub webPages {
 				args   => \@_
 			} );
 		} );
+	} else {
+		Slim::Web::Pages->delPageLinks( 'plugins', 'PLUGIN_MUSICARTISTINFO_ALBUMS_MISSING_ARTWORK' );
+	}
 
-		$url = 'plugins/' . PLUGIN_TAG . '/smallartwork.html';
+	$url = 'plugins/' . PLUGIN_TAG . '/smallartwork.html';
 
+	if (!$prefs->get('hidextramenusitems')) {
 		Slim::Web::Pages->addPageLinks( 'plugins', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => $url } );
 		Slim::Web::Pages->addPageLinks( 'icons', { PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK => "html/images/cover.png" });
 
@@ -132,6 +136,8 @@ sub webPages {
 				args   => \@_
 			} );
 		} );
+	} else {
+		Slim::Web::Pages->delPageLinks( 'plugins', 'PLUGIN_MUSICARTISTINFO_ALBUMS_SMALL_ARTWORK' );
 	}
 }
 

--- a/Settings.pm
+++ b/Settings.pm
@@ -16,7 +16,7 @@ sub name {
 
 sub prefs {
 	return ($prefs, qw(browseArtistPictures runImporter lookupArtistPictures lookupCoverArt reviewFolder artistImageFolder lyricsFolder bioFolder
-		lookupAlbumArtistPicturesOnly saveMissingArtistPicturePlaceholder replaceOnlineGenres fallBackToEnglish));
+		lookupAlbumArtistPicturesOnly saveMissingArtistPicturePlaceholder replaceOnlineGenres fallBackToEnglish hidextramenusitems));
 }
 
 sub page {

--- a/strings.txt
+++ b/strings.txt
@@ -179,7 +179,7 @@ PLUGIN_MUSICARTISTINFO_REVIEWS_FOLDER
 PLUGIN_MUSICARTISTINFO_REVIEWS_FOLDER_DESC
 	DE	Falls Sie einen Ordner für Albumkritiken angeben, so werden darin gespeicherte Texte verwendet. Verwenden Sie Dateinamen im Stil %ARTIST/%ALBUM.txt (html, nfo, z.B. 'Peter Gabriel/So.html'), wobei der Dateiname der Schreibweise in ihren Musikdateien entsprechen muss.
 	EN	If you decide to use a folder for album reviews, this will be used as an additional source for textual content. Use filenames like %ARTIST/%ALBUM.txt (html, nfo, eg. 'Peter Gabriel/So.html'). If a file is found in this folder, then no online-source will be used.
-	FR	Si vous spécifiez un dossier pour les critiques d'albums, les critiques qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST/%ALBUM.txt (html, nfo, par exemple "Peter Gabriel/So.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
+	FR	Si vous spécifiez un dossier pour les critiques d'albums, les fichiers qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST/%ALBUM.txt (html, nfo, par exemple "Peter Gabriel/So.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
 	NL	Als je een map gebruikt voor recensies, wordt deze gebruikt als een additionele bron voor recensies. Gebruik bestandsnamen als %ARTIST/%ALBUM.txt (html, nfo, bijv. 'Peter Gabriel/So.txt'). Als er een bestand in de map staat, wordt er geen online bron gebruikt.
 
 PLUGIN_MUSICARTISTINFO_BIOS_FOLDER
@@ -191,7 +191,7 @@ PLUGIN_MUSICARTISTINFO_BIOS_FOLDER
 PLUGIN_MUSICARTISTINFO_BIOS_FOLDER_DESC
 	DE	Falls Sie einen Ordner für Biographien angeben, so werden darin gespeicherte Texte verwendet. Verwenden Sie Dateinamen im Stil %ARTIST.txt (html, nfo, z.B. 'Peter Gabriel.html'), wobei der Dateiname der Schreibweise in ihren Musikdateien entsprechen muss.
 	EN	If you decide to use a folder for biographies, this will be used as an additional source for textual content. Use filenames like %ARTIST.txt (html, nfo, eg. 'Peter Gabriel.html'). If a file is found in this folder, then no online-source will be used.
-	FR	Si vous spécifiez un dossier pour les biographies d'artistes, les biographies qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST.txt (html, nfo, par exemple "Peter Gabriel.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
+	FR	Si vous spécifiez un dossier pour les biographies d'artistes, les fichiers qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST.txt (html, nfo, par exemple "Peter Gabriel.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
 	NL	Als je een map gebruikt voor biografieën van artiesten, wordt deze gebruikt als een additionele bron voor biografieën. Gebruik bestandsnamen als %ARTIST.txt (html, nfo, bijv. 'Peter Gabriel.txt'). Als er een bestand in de map staat, wordt er geen online bron gebruikt.
 
 PLUGIN_MUSICARTISTINFO_ARTISTPHOTOS_SAVE_DISABLED
@@ -257,7 +257,7 @@ PLUGIN_MUSICARTISTINFO_IMPORTER_ALBUMARTIST_ONLY
 PLUGIN_MUSICARTISTINFO_IMPORTER_PLACEHOLDER
 	DE	Speichere Platzhalter-Datei ("artist.missing") falls Interpreten-Bilder heruntergeladen werden sollen, aber nicht gefunden werden.
 	EN	Store placeholder file ("artist.missing") if artist pictures are to be downloaded, but cannot be found.
-	FR	Enregistrer un fichier "artiste.missing" pour les artistes dont la photo a été recherchée mais pas trouvée.
+	FR	Enregistrer un fichier "artist.missing" pour les artistes dont la photo a été recherchée mais pas trouvée.
 	NL	Maak een bestand ("artist.missing") aan als de foto van de artiest dient te worden gedownload maar niet kan worden gevonden.
 
 PLUGIN_MUSICARTISTINFO_IMPORTER_COVERART
@@ -287,7 +287,12 @@ PLUGIN_MUSICARTISTINFO_IMPORTER_GENRES_DESC
 PLUGIN_MUSICARTISTINFO_ENGLISH_CONTENT_FALLBACK
 	DE	Englische Inhalte anzeigen, wenn Deutsch nicht verfügbar ist.
 	EN	Fall back to English content if your language isn't available.
-	FR	Afficher des informations en anglais lorsque le français n'est pas disponible.
+
+PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS
+	EN	Hide Extra menu items
+
+PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS_DESC
+	EN	Hide “Find albums“ items from the Extra menu. Requires a server restart.
 
 PLUGIN_MUSICARTISTINFO_SORRY
 	DE	Tut mir Leid, aber um alle Möglichkeiten dieses Plugins auszureizen (z.B. Interpreten-Bilder beim durchsuchen deiner Interpreten-Liste) benötigst du mindestens Logitech Media Server 7.8.
@@ -316,7 +321,6 @@ PLUGIN_MUSICARTISTINFO_UNSUPPORTED_CT
 PLUGIN_MUSICARTISTINFO_READ_MORE
 	DE	Ganzen Artikel auf Wikipedia lesen...
 	EN	Read full article on Wikipedia...
-	FR	Lire l'article complet sur Wikipedia...
 
 # language codes to be used in Last.fm lookups - only these available, otherwise fall back to English
 PLUGIN_MUSICARTISTINFO_LASTFM_LANGUAGE

--- a/strings.txt
+++ b/strings.txt
@@ -179,7 +179,7 @@ PLUGIN_MUSICARTISTINFO_REVIEWS_FOLDER
 PLUGIN_MUSICARTISTINFO_REVIEWS_FOLDER_DESC
 	DE	Falls Sie einen Ordner für Albumkritiken angeben, so werden darin gespeicherte Texte verwendet. Verwenden Sie Dateinamen im Stil %ARTIST/%ALBUM.txt (html, nfo, z.B. 'Peter Gabriel/So.html'), wobei der Dateiname der Schreibweise in ihren Musikdateien entsprechen muss.
 	EN	If you decide to use a folder for album reviews, this will be used as an additional source for textual content. Use filenames like %ARTIST/%ALBUM.txt (html, nfo, eg. 'Peter Gabriel/So.html'). If a file is found in this folder, then no online-source will be used.
-	FR	Si vous spécifiez un dossier pour les critiques d'albums, les fichiers qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST/%ALBUM.txt (html, nfo, par exemple "Peter Gabriel/So.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
+	FR	Si vous spécifiez un dossier pour les critiques d'albums, les critiques qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST/%ALBUM.txt (html, nfo, par exemple "Peter Gabriel/So.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
 	NL	Als je een map gebruikt voor recensies, wordt deze gebruikt als een additionele bron voor recensies. Gebruik bestandsnamen als %ARTIST/%ALBUM.txt (html, nfo, bijv. 'Peter Gabriel/So.txt'). Als er een bestand in de map staat, wordt er geen online bron gebruikt.
 
 PLUGIN_MUSICARTISTINFO_BIOS_FOLDER
@@ -191,7 +191,7 @@ PLUGIN_MUSICARTISTINFO_BIOS_FOLDER
 PLUGIN_MUSICARTISTINFO_BIOS_FOLDER_DESC
 	DE	Falls Sie einen Ordner für Biographien angeben, so werden darin gespeicherte Texte verwendet. Verwenden Sie Dateinamen im Stil %ARTIST.txt (html, nfo, z.B. 'Peter Gabriel.html'), wobei der Dateiname der Schreibweise in ihren Musikdateien entsprechen muss.
 	EN	If you decide to use a folder for biographies, this will be used as an additional source for textual content. Use filenames like %ARTIST.txt (html, nfo, eg. 'Peter Gabriel.html'). If a file is found in this folder, then no online-source will be used.
-	FR	Si vous spécifiez un dossier pour les biographies d'artistes, les fichiers qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST.txt (html, nfo, par exemple "Peter Gabriel.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
+	FR	Si vous spécifiez un dossier pour les biographies d'artistes, les biographies qu'il contient seront utilisées en priorité sur celles trouvées sur internet. Utilisez des noms de fichiers de la forme %ARTIST.txt (html, nfo, par exemple "Peter Gabriel.txt"), où le nom du fichier doit correspondre exactement au nom de l'artiste dans les fichiers musicaux.
 	NL	Als je een map gebruikt voor biografieën van artiesten, wordt deze gebruikt als een additionele bron voor biografieën. Gebruik bestandsnamen als %ARTIST.txt (html, nfo, bijv. 'Peter Gabriel.txt'). Als er een bestand in de map staat, wordt er geen online bron gebruikt.
 
 PLUGIN_MUSICARTISTINFO_ARTISTPHOTOS_SAVE_DISABLED
@@ -257,7 +257,7 @@ PLUGIN_MUSICARTISTINFO_IMPORTER_ALBUMARTIST_ONLY
 PLUGIN_MUSICARTISTINFO_IMPORTER_PLACEHOLDER
 	DE	Speichere Platzhalter-Datei ("artist.missing") falls Interpreten-Bilder heruntergeladen werden sollen, aber nicht gefunden werden.
 	EN	Store placeholder file ("artist.missing") if artist pictures are to be downloaded, but cannot be found.
-	FR	Enregistrer un fichier "artist.missing" pour les artistes dont la photo a été recherchée mais pas trouvée.
+	FR	Enregistrer un fichier "artiste.missing" pour les artistes dont la photo a été recherchée mais pas trouvée.
 	NL	Maak een bestand ("artist.missing") aan als de foto van de artiest dient te worden gedownload maar niet kan worden gevonden.
 
 PLUGIN_MUSICARTISTINFO_IMPORTER_COVERART
@@ -287,6 +287,7 @@ PLUGIN_MUSICARTISTINFO_IMPORTER_GENRES_DESC
 PLUGIN_MUSICARTISTINFO_ENGLISH_CONTENT_FALLBACK
 	DE	Englische Inhalte anzeigen, wenn Deutsch nicht verfügbar ist.
 	EN	Fall back to English content if your language isn't available.
+	FR	Afficher des informations en anglais lorsque le français n'est pas disponible.
 
 PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS
 	EN	Hide Extra menu items
@@ -321,6 +322,7 @@ PLUGIN_MUSICARTISTINFO_UNSUPPORTED_CT
 PLUGIN_MUSICARTISTINFO_READ_MORE
 	DE	Ganzen Artikel auf Wikipedia lesen...
 	EN	Read full article on Wikipedia...
+	FR	Lire l'article complet sur Wikipedia...
 
 # language codes to be used in Last.fm lookups - only these available, otherwise fall back to English
 PLUGIN_MUSICARTISTINFO_LASTFM_LANGUAGE

--- a/strings.txt
+++ b/strings.txt
@@ -293,7 +293,7 @@ PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS
 	EN	Hide Extra menu items
 
 PLUGIN_MUSICARTISTINFO_HIDEEXTRAMENUITEMS_DESC
-	EN	Hide “Find albums“ items from the Extra menu. Requires a server restart.
+	EN	Hide “Find albums“ items from the Extra menu.
 
 PLUGIN_MUSICARTISTINFO_SORRY
 	DE	Tut mir Leid, aber um alle Möglichkeiten dieses Plugins auszureizen (z.B. Interpreten-Bilder beim durchsuchen deiner Interpreten-Liste) benötigst du mindestens Logitech Media Server 7.8.


### PR DESCRIPTION
Just a small preference setting to hide the 2(?) 'Find albums...' menu items from the LMS Extra menu. 
Disabled by default, so no harm done, but there if you need it.
Hope that's ok with you.